### PR TITLE
Better error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pil-bot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pil-bot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A discord bot for personal usage",
   "scripts": {
     "test": "echo 'No test specified'",

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -16,7 +16,8 @@
                     return resp;
                 }
                 else {
-                    var err = new Error(resp.body.message);
+                    var errMsg = [resp.statusCode, resp.statusMessage, ':', resp.body.message].join(' ');
+                    var err = new Error(errMsg);
                     rollbar.errorRequest(err, resp.request);
                     logger.error('Received an error from Twitch:', resp.statusCode, resp.statusMessage, resp.body);
                     throw err;

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -16,10 +16,10 @@
                     return resp;
                 }
                 else {
-                    var errMsg = [resp.statusCode, resp.statusMessage, ':', resp.body.message].join(' ');
+                    var errMsg = [resp.statusCode, resp.statusMessage, ':', resp.body.message || resp.body].join(' ');
                     var err = new Error(errMsg);
                     rollbar.errorRequest(err, resp.request);
-                    logger.error('Received an error from Twitch:', resp.statusCode, resp.statusMessage, resp.body);
+                    logger.error('Received an error from Twitch:', errMsg);
                     throw err;
                 }
             });


### PR DESCRIPTION
This is to address the errors where `resp.body.message` is empty due to an error. In that case, fall back to logging the whole body. Adding status code and status message won't hurt. 